### PR TITLE
Refine TFRecord reader to return images and labels

### DIFF
--- a/test_read_record.py
+++ b/test_read_record.py
@@ -1,0 +1,48 @@
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+tf.disable_v2_behavior()
+
+from utils.tf_record import read_record
+
+
+def _bytes_feature(value):
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+
+def _create_dummy_tfrecord(path, size=2):
+    """Create a minimal TFRecord file for testing."""
+    image = (np.random.rand(size, size, 3) * 255).astype(np.uint8)
+    wall = np.zeros((size, size, 1), dtype=np.uint8)
+    close = np.zeros((size, size, 1), dtype=np.uint8)
+    room = np.zeros((size, size), dtype=np.uint8)
+    close_wall = np.zeros((size, size, 1), dtype=np.uint8)
+
+    features = {
+        "image": _bytes_feature(image.tobytes()),
+        "wall": _bytes_feature(wall.tobytes()),
+        "close": _bytes_feature(close.tobytes()),
+        "room": _bytes_feature(room.tobytes()),
+        "close_wall": _bytes_feature(close_wall.tobytes()),
+    }
+    example = tf.train.Example(features=tf.train.Features(feature=features))
+    with tf.io.TFRecordWriter(path) as writer:
+        writer.write(example.SerializeToString())
+
+
+def test_read_record(tmp_path):
+    tfrecord_path = tmp_path / "dummy.tfrecords"
+    _create_dummy_tfrecord(str(tfrecord_path), size=2)
+
+    loader = read_record(str(tfrecord_path), batch_size=1, size=2)
+    with tf.Session() as sess:
+        coord = tf.train.Coordinator()
+        threads = tf.train.start_queue_runners(coord=coord)
+        images, labels = sess.run([loader["images"], loader["labels"]])
+        coord.request_stop()
+        coord.join(threads)
+
+    assert images.shape == (1, 2, 2, 3)
+    # wall(1) + close(1) + room(9 one-hot) + close_wall(1) = 12
+    assert labels.shape == (1, 2, 2, 12)
+

--- a/utils/tf_record.py
+++ b/utils/tf_record.py
@@ -125,18 +125,21 @@ def read_record(data_path, batch_size=1, size=512):
 	close = tf.divide(close, tf.constant(255.0))
 	close_wall = tf.divide(close_wall, tf.constant(255.0))
 
-	# Genereate one hot room label
-	room_one_hot = tf.one_hot(room, 9, axis=-1)
+        # Genereate one hot room label
+        room_one_hot = tf.one_hot(room, 9, axis=-1)
 
-	# Creates batches by randomly shuffling tensors
-	images, walls, closes, rooms, close_walls = tf.train.shuffle_batch([image, wall, close, room_one_hot, close_wall], 
-						batch_size=batch_size, capacity=batch_size*128, num_threads=1, min_after_dequeue=batch_size*32)	
+        # Combine all labels into a single tensor
+        labels = tf.concat([wall, close, room_one_hot, close_wall], axis=2)
 
-	# images, walls = tf.train.shuffle_batch([image, wall], 
-						# batch_size=batch_size, capacity=batch_size*128, num_threads=1, min_after_dequeue=batch_size*32)	
+        # Creates batches by randomly shuffling tensors
+        images, labels = tf.train.shuffle_batch(
+                [image, labels],
+                batch_size=batch_size,
+                capacity=batch_size*128,
+                num_threads=1,
+                min_after_dequeue=batch_size*32)
 
-	return {'images': images, 'walls': walls, 'closes': closes, 'rooms': rooms, 'close_walls': close_walls}
-	# return {'images': images, 'walls': walls}
+        return {'images': images, 'labels': labels}
 
 # ------------------------------------------------------------------------------------------------------------------------------------- *
 # Following are only for segmentation task, merge all label into one 


### PR DESCRIPTION
## Summary
- consolidate TFRecord labels into single tensor
- expose simple `{'images', 'labels'}` interface
- add unit test that exercises the TFRecord reading pipeline

## Testing
- `pytest test_read_record.py -q` *(fails: No module named 'numpy')*
- `pip install tensorflow-cpu==2.12.1` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894d1a29150832a875328d32e2471b6