### PR TITLE
Fix Python3 compatibility by replacing xrange and print statements

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,19 +58,19 @@ class MODEL(Network):
 
 		m_c = [] # index mask
 		n_c = [] # each class foreground pixels
-		for c in xrange(num_classes):
+		for c in range(num_classes):
 			m_c.append(tf.cast(tf.equal(ind, c), dtype=tf.int32))
 			n_c.append(tf.cast(tf.reduce_sum(m_c[-1]), dtype=tf.float32))
 
 		# compute count
 		c = []
-		for i in xrange(num_classes):
+		for i in range(num_classes):
 			c.append(total - n_c[i])
 		tc = tf.add_n(c)
 
 		# use for compute loss
 		loss = 0.
-		for i in xrange(num_classes): 
+		for i in range(num_classes): 
 			w = c[i] / tc
 			m_c_one_hot = tf.one_hot((i*m_c[i]), num_classes, axis=-1)
 			y_c = m_c_one_hot*y
@@ -85,7 +85,7 @@ class MODEL(Network):
 		labels_cw_hot  = loader_dict['label_boundaries']
 
 		max_ep = max_step // num_batch
-		print 'max_step = {}, max_ep = {}, num_batch = {}'.format(max_step, max_ep, num_batch)
+		print('max_step = {}, max_ep = {}, num_batch = {}'.format(max_step, max_ep, num_batch))
 
 		logits1, logits2 = self.forward(images, init_with_pretrain_vgg=False)
 
@@ -134,11 +134,11 @@ class MODEL(Network):
 			# start queue 
 			threads = tf.train.start_queue_runners(sess=sess, coord=coord)
 
-			print "Start Training!"
+			print("Start Training!")
 			total_times = 0			
 
-			for ep in xrange(max_ep): # epoch loop
-				for n in xrange(num_batch): # batch loop
+			for ep in range(max_ep): # epoch loop
+				for n in range(num_batch): # batch loop
 					tic = time.time()
 					# [loss_value, update_value, summaries] = sess.run([loss, optim, merged])	
 					[loss_value, update_value] = sess.run([loss, optim])	
@@ -148,8 +148,8 @@ class MODEL(Network):
 
 					step = int(ep*num_batch + n)
 					# write log 
-					print 'step {}: loss = {:.3}; {:.2} data/sec, excuted {} minutes'.format(step,
-						loss_value, 1.0/duration, int(total_times/60))
+					print('step {}: loss = {:.3}; {:.2} data/sec, excuted {} minutes'.format(step,
+						loss_value, 1.0/duration, int(total_times/60)))
 					# writer.add_summary(summaries, global_step=step)
 				# save model parameters after 2 epoch training
 				if ep % 2 == 0:
@@ -164,7 +164,7 @@ class MODEL(Network):
 			sess.close()	
 
 	def infer(self, save_dir='out', resize=True, merge=True):
-		print "generating test set of {}.... will save to [./{}]".format(self.eval_file, save_dir)
+		print("generating test set of {}.... will save to [./{}]".format(self.eval_file, save_dir))
 		room_dir = os.path.join(save_dir, 'room')
 		close_wall_dir = os.path.join(save_dir, 'boundary')
 
@@ -228,7 +228,7 @@ class MODEL(Network):
 				imsave(save_path3, out3_rgb)
 			# imsave(save_path4, out4)
 			
-			print 'Saving prediction: {}'.format(name)	
+			print('Saving prediction: {}'.format(name))	
 
 	def evaluate(self, sess, epoch, num_of_classes=11):
 		x = tf.placeholder(shape=[1, 512, 512, 3], dtype=tf.float32)
@@ -245,7 +245,7 @@ class MODEL(Network):
 		n = len(paths)
 
 		hist = np.zeros((num_of_classes, num_of_classes))
-		for i in xrange(n):
+		for i in range(n):
 			im = imread(image_paths[i], mode='RGB')
 			# for fuse label
 			dd = imread(gt2_paths[i], mode='L')
@@ -279,10 +279,10 @@ class MODEL(Network):
 		mean_acc9 = (np.nansum(mean_acc[:7])+mean_acc[-2]+mean_acc[-1]) / 9.
 
 		file = open('EVAL_'+self.log_dir, 'a')
-		print>>file, 'Model at epoch {}: overall accuracy = {:.4}, mean_acc = {:.4}'.format(epoch, overall_acc, mean_acc9)
-		for i in xrange(mean_acc.shape[0]):
+		print('Model at epoch {}: overall accuracy = {:.4}, mean_acc = {:.4}'.format(epoch, overall_acc, mean_acc9), file=file)
+		for i in range(mean_acc.shape[0]):
 			if i not in [7 ,8]: # ingore class 7 & 8 
-				print>>file, '\t\tepoch {}: {}th label: accuracy = {:.4}'.format(epoch, i, mean_acc[i])		
+				print('\t\tepoch {}: {}th label: accuracy = {:.4}'.format(epoch, i, mean_acc[i]), file=file)		
 		file.close()
 
 def main(args):
@@ -299,7 +299,7 @@ def main(args):
 		tic = time.time()
 		model.train(loader_dict, num_batch)
 		toc = time.time()
-		print 'total training + evaluation time = {} minutes'.format((toc-tic)/60)
+		print('total training + evaluation time = {} minutes'.format((toc-tic)/60))
 	elif args.phase.lower() == 'test':	
 		model.infer()
 	else:

--- a/postprocess.py
+++ b/postprocess.py
@@ -29,7 +29,7 @@ def post_process(input_dir, save_dir, merge=True):
 
 	n = len(input_paths)
 	# n = 1
-	for i in xrange(n):
+	for i in range(n):
 		im = imread(input_paths[i], mode='RGB')
 		im_ind = rgb2ind(im, color_map=floorplan_fuse_map)
 		# seperate image into room-seg & boundary-seg
@@ -64,7 +64,7 @@ def post_process(input_dir, save_dir, merge=True):
 		# ignore the background mislabeling
 		new_rm_ind = fuse_mask*new_rm_ind
 
-		print 'Saving {}th refined room prediciton to {}'.format(i, out_paths[i])
+		print('Saving {}th refined room prediciton to {}'.format(i, out_paths[i]))
 		if merge:
 			new_rm_ind[bd_ind==9] = 9
 			new_rm_ind[bd_ind==10] = 10

--- a/scores.py
+++ b/scores.py
@@ -33,7 +33,7 @@ def evaluate_semantic(benchmark_path, result_dir, num_of_classes=11, need_merge_
 	n = len(im_paths)
 	# n = 1
 	hist = np.zeros((num_of_classes, num_of_classes))
-	for i in xrange(n):
+	for i in range(n):
 		im = imread(im_paths[i], mode='RGB')
 		if need_merge_result:
 			im_d = imread(im_d_paths[i], mode='L')
@@ -82,28 +82,28 @@ def evaluate_semantic(benchmark_path, result_dir, num_of_classes=11, need_merge_
 		name = im_paths[i].split('/')[-1]
 		r_name = r_paths[i].split('/')[-1]
 		
-		print 'Evaluating {}(im) <=> {}(gt)...'.format(name, r_name)
+		print('Evaluating {}(im) <=> {}(gt)...'.format(name, r_name))
 
 		hist += fast_hist(im_ind.flatten(), rr_ind.flatten(), num_of_classes)
 
-	print '*'*60
+	print('*'*60)
 	# overall accuracy
 	acc = np.diag(hist).sum() / hist.sum()
-	print 'overall accuracy {:.4}'.format(acc)
+	print('overall accuracy {:.4}'.format(acc))
 	# per-class accuracy, avoid div zero
 	acc = np.diag(hist) / (hist.sum(1) + 1e-6)
-	print 'room-type: mean accuracy {:.4}, room-type+bd: mean accuracy {:.4}'.format(np.nanmean(acc[:7]), (np.nansum(acc[:7])+np.nansum(acc[-2:]))/9.)
-	for t in xrange(0, acc.shape[0]):
+	print('room-type: mean accuracy {:.4}, room-type+bd: mean accuracy {:.4}'.format(np.nanmean(acc[:7]), (np.nansum(acc[:7])+np.nansum(acc[-2:]))/9.))
+	for t in range(0, acc.shape[0]):
 		if t not in [7, 8]:
-			print 'room type {}th, accuracy = {:.4}'.format(t, acc[t])
+			print('room type {}th, accuracy = {:.4}'.format(t, acc[t]))
 
-	print '*'*60
+	print('*'*60)
 	# per-class IU, avoid div zero
 	iu = np.diag(hist) / (hist.sum(1) + 1e-6 + hist.sum(0) - np.diag(hist))
-	print 'room-type: mean IoU {:.4}, room-type+bd: mean IoU {:.4}'.format(np.nanmean(iu[:7]), (np.nansum(iu[:7])+np.nansum(iu[-2:]))/9.)
-	for t in xrange(iu.shape[0]):
+	print('room-type: mean IoU {:.4}, room-type+bd: mean IoU {:.4}'.format(np.nanmean(iu[:7]), (np.nansum(iu[:7])+np.nansum(iu[-2:]))/9.))
+	for t in range(iu.shape[0]):
 		if t not in [7,8]: # ignore class 7 & 8
-			print 'room type {}th, IoU = {:.4}'.format(t, iu[t])
+			print('room type {}th, IoU = {:.4}'.format(t, iu[t]))
 
 if __name__ == '__main__':
 	FLAGS, unparsed = parser.parse_known_args()
@@ -118,5 +118,5 @@ if __name__ == '__main__':
 	tic = time.time()
 	evaluate_semantic(benchmark_path, result_dir, need_merge_result=False, im_downsample=False, gt_downsample=True) # same as previous line but 11 classes by combining the opening and wall line
 
-	print "*"*60
-	print "Evaluate time: {} sec".format(time.time()-tic)
+	print("*"*60)
+	print("Evaluate time: {} sec".format(time.time()-tic))

--- a/utils/util.py
+++ b/utils/util.py
@@ -49,7 +49,7 @@ def fill_break_line(cw_mask):
 def refine_room_region(cw_mask, rm_ind):
 	label_rm, num_label = ndimage.label((1-cw_mask))
 	new_rm_ind = np.zeros(rm_ind.shape)
-	for j in xrange(1, num_label+1):  
+	for j in range(1, num_label+1):  
 		mask = (label_rm == j).astype(np.uint8)
 		ys, xs = np.where(mask!=0)
 		area = (np.amax(xs)-np.amin(xs))*(np.amax(ys)-np.amin(ys))


### PR DESCRIPTION
## Summary
- Replace deprecated `xrange` with `range` in utility, postprocess, scoring, and main modules
- Convert legacy Python2 `print` statements to Python3 function form

## Testing
- `python -m py_compile main.py postprocess.py scores.py utils/util.py`
- Attempted `python test_basic.py` but failed: `ModuleNotFoundError: No module named 'numpy'`
- Attempted dependency install: `pip install numpy` (failed: 403 proxy error)


------
https://chatgpt.com/codex/tasks/task_e_6894d4d40384832aa0f6ffa9d35747e2