### PR TITLE
refactor: replace deprecated scipy.misc image ops with PIL

### DIFF
--- a/postprocess.py
+++ b/postprocess.py
@@ -7,7 +7,7 @@ import time
 import random
 
 import numpy as np
-from scipy.misc import imread, imresize, imsave
+from PIL import Image
 from matplotlib import pyplot as plt
 
 sys.path.append('./utils/')
@@ -18,6 +18,12 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument('--result_dir', type=str, default='./out',
 					help='The folder that save network predictions.')
+
+def imread(path, mode='RGB'):
+        return np.array(Image.open(path).convert(mode))
+
+def imsave(path, array):
+        Image.fromarray(array).save(path)
 
 def post_process(input_dir, save_dir, merge=True):
 	if not os.path.exists(save_dir):

--- a/scores.py
+++ b/scores.py
@@ -1,6 +1,6 @@
 import argparse
 import numpy as np
-from scipy.misc import imread, imsave, imresize
+from PIL import Image
 
 import os
 import sys
@@ -10,6 +10,17 @@ import time
 sys.path.append('./utils/')
 from metrics import fast_hist
 from rgb_ind_convertor import *
+
+
+def imread(path, mode='RGB'):
+        return np.array(Image.open(path).convert(mode))
+
+
+def imresize(arr, size, resample=Image.NEAREST):
+        if len(size) == 3:
+                size = size[:2]
+        img = Image.fromarray(arr)
+        return np.array(img.resize((size[1], size[0]), resample))
 
 parser = argparse.ArgumentParser()
 

--- a/utils/tf_record.py
+++ b/utils/tf_record.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import tensorflow as tf
 
-from scipy.misc import imread, imresize, imsave
+from PIL import Image
 from matplotlib import pyplot as plt
 from rgb_ind_convertor import *
 
@@ -10,6 +10,15 @@ import os
 import sys
 import glob 
 import time
+
+def imread(path, mode='RGB'):
+	return np.array(Image.open(path).convert(mode))
+
+def imresize(arr, size, resample=Image.NEAREST):
+	if len(size) == 3:
+		size = size[:2]
+	img = Image.fromarray(arr)
+	return np.array(img.resize((size[1], size[0]), resample))
 
 def load_raw_images(path):
 	paths = path.split('\t')


### PR DESCRIPTION
## Summary
- replace removed `scipy.misc` image functions with Pillow equivalents
- add local `imread`, `imresize`, and `imsave` helpers using `PIL.Image`

## Testing
- `pytest test_basic.py test_final.py test_import.py test_environment.py test_read_record.py test_closet_toggle.py test_ocr.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pillow -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6894d782f2c0832a82490a00d9f7dcc7