### PR TITLE
Replace deprecated np.int usage

### DIFF
--- a/utils/util.py
+++ b/utils/util.py
@@ -14,13 +14,13 @@ def flood_fill(test_array, h_max=255):
 	fill in the hole 
 	"""
 	input_array = np.copy(test_array) 
-	el = ndimage.generate_binary_structure(2,2).astype(np.int)
+	el = ndimage.generate_binary_structure(2,2).astype(int)
 	inside_mask = ndimage.binary_erosion(~np.isnan(input_array), structure=el)
 	output_array = np.copy(input_array)
 	output_array[inside_mask]=h_max
 	output_old_array = np.copy(input_array)
 	output_old_array.fill(0)   
-	el = ndimage.generate_binary_structure(2,1).astype(np.int)
+	el = ndimage.generate_binary_structure(2,1).astype(int)
 	while not np.array_equal(output_old_array, output_array):
 		output_old_array = np.copy(output_array)
 		output_array = np.maximum(input_array,ndimage.grey_erosion(output_array, size=(3,3), footprint=el))


### PR DESCRIPTION
## Summary
- replace deprecated `np.int` with built-in `int` in flood-fill utility

## Testing
- `pytest test_basic.py test_closet_toggle.py test_environment.py test_final.py test_import.py test_ocr.py test_read_record.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pillow matplotlib scipy opencv-python` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6894db3c9868832a9eeb3f70096f7904