### PR TITLE
fix: align OCR boxes with segmentation

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -283,6 +283,17 @@ def main(args):
         
         # Extract textual room labels using OCR with enhanced image
         ocr_results = extract_room_text(ocr_im)
+        # Scale OCR bounding boxes to match segmentation size (512x512)
+        if ocr_results:
+                scale_x = im.shape[1] / ocr_im.shape[1]
+                scale_y = im.shape[0] / ocr_im.shape[0]
+                for item in ocr_results:
+                        x, y, w, h = item['bbox']
+                        x = int(x * scale_x)
+                        y = int(y * scale_y)
+                        w = int(w * scale_x)
+                        h = int(h * scale_y)
+                        item['bbox'] = (x, y, w, h)
         
         # Convert to float and normalize for network inference
         im = im.astype(np.float32) / 255.

--- a/demo_fixed.py
+++ b/demo_fixed.py
@@ -256,6 +256,17 @@ def main(args):
     
     # Extract textual room labels using OCR with enhanced image
     ocr_results = extract_room_text(ocr_im)
+    # Scale OCR bounding boxes to match segmentation size (512x512)
+    if ocr_results:
+        scale_x = im.shape[1] / ocr_im.shape[1]
+        scale_y = im.shape[0] / ocr_im.shape[0]
+        for item in ocr_results:
+            x, y, w, h = item['bbox']
+            x = int(x * scale_x)
+            y = int(y * scale_y)
+            w = int(w * scale_x)
+            h = int(h * scale_y)
+            item['bbox'] = (x, y, w, h)
     
     # Convert to float and normalize for network inference
     im = im.astype(np.float32) / 255.


### PR DESCRIPTION
## Summary
- scale OCR bounding boxes to match 512×512 segmentation map
- apply same correction in demo_fixed script to keep behavior consistent

## Testing
- `python demo.py --im_path=./demo/45765448.jpg` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy due to proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_6895d3f6b1d4832a8ff8cd335d77a86e