### PR TITLE
Ensure preprocess_image uses float32 arrays

### DIFF
--- a/demo_refactored_clean.py
+++ b/demo_refactored_clean.py
@@ -1085,7 +1085,7 @@ class FloorplanProcessor:
 
         # 调整到模型输入尺寸 (512x512)
         img_resized = img.resize((512, 512), Image.LANCZOS)
-        img_array = np.array(img_resized) / 255.0
+        img_array = np.array(img_resized, dtype=np.float32) / 255.0
 
         print(f"🔄 神经网络输入: 512 x 512 (固定尺寸)")
 


### PR DESCRIPTION
## Summary
- Normalize resized images using float32 arrays in `preprocess_image` for compatibility with downstream processing.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68abb3341750832ab87aa91567413e0e