### PR TITLE
Convert image viewer helper to static method

### DIFF
--- a/demo_refactored_clean.py
+++ b/demo_refactored_clean.py
@@ -2170,6 +2170,7 @@ class FloorplanProcessor:
         if hasattr(self, 'ai_engine') and hasattr(self.ai_engine, 'session') and self.ai_engine.session:
             self.ai_engine.session.close()
 
+    @staticmethod
     def open_image_with_system_viewer(image_path):
         """使用系统默认图片查看器打开图片"""
         try:


### PR DESCRIPTION
## Summary
- make `open_image_with_system_viewer` a `@staticmethod` in `FloorplanProcessor`
- ensure fallback call uses `FloorplanProcessor.open_image_with_system_viewer`

## Testing
- `python -m py_compile demo_refactored_clean.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68abcd544dac832aa726613168e00d6b