### PR TITLE
Add TensorFlow availability check and document dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the code & annotation data for our ICCV 2019 paper: ['D
 
 - Please install OpenCV
 - Please install Python 2.7
-- Please install tensorflow-gpu
+- Please install TensorFlow ≥ 1.x (e.g., `tensorflow-gpu==1.10.1`)
 
 Our code has been tested by using tensorflow-gpu==1.10.1 & OpenCV==3.1.0. We used Nvidia Titan Xp GPU with CUDA 9.0 installed.
 

--- a/demo_refactored_clean.py
+++ b/demo_refactored_clean.py
@@ -115,6 +115,9 @@ class FloorplanProcessor:
 
     def __init__(self, model_path="pretrained"):
         """初始化四层架构处理器"""
+        if getattr(tf, "__class__", type(tf)).__name__ == "_DummyTF":
+            raise ImportError("请安装 TensorFlow ≥ 1.x")
+
         print("🏠 DeepFloorplan 房间检测 - 四层智能决策架构")
         print("=" * 60)
 
@@ -130,6 +133,8 @@ class FloorplanProcessor:
 
     def load_model(self):
         """加载AI分割模型"""
+        if getattr(tf, "__class__", type(tf)).__name__ == "_DummyTF":
+            raise ImportError("请安装 TensorFlow ≥ 1.x")
         self.ai_engine.load_model()
 
     def preprocess_image(self, image_path):


### PR DESCRIPTION
## Summary
- ensure FloorplanProcessor fails fast when TensorFlow is missing
- document TensorFlow ≥ 1.x requirement in README

## Testing
- `python -m pytest -q` *(fails: No module named 'numpy')*
- `python -m pytest test_bathroom_shower.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1035e86f4832a81c6672f215a6300