### PR TITLE
Add fengshui missing corner analysis utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ or
 python postprocess.py --result_dir=./[result_folder_path]
 ```
 
+## Fengshui analysis
+
+A simple tool is provided to analyze missing corners of a floorplan based on Luo Shu nine-palace principles.
+
+```bash
+python analyze_fengshui.py path/to/floorplan.json --threshold 0.6
+# or
+python -m fengshui path/to/floorplan.json --threshold 0.6
+```
+
+The command prints detected missing directions and suggestions and can save the report with `--output`.
+
+
 ## Citation
 
 If you find our work useful in your research, please consider citing:

--- a/analyze_fengshui.py
+++ b/analyze_fengshui.py
@@ -1,0 +1,5 @@
+"""Command line utility to analyze floorplan fengshui."""
+from fengshui.__main__ import main
+
+if __name__ == "__main__":
+    main()

--- a/fengshui/__init__.py
+++ b/fengshui/__init__.py
@@ -1,0 +1,5 @@
+"""Fengshui utilities for floorplan analysis."""
+
+from .luoshu_missing_corner import analyze_missing_corners
+
+__all__ = ["analyze_missing_corners"]

--- a/fengshui/__main__.py
+++ b/fengshui/__main__.py
@@ -1,0 +1,37 @@
+import argparse
+import json
+
+from editor.json_io import load_floorplan_json
+from . import luoshu_missing_corner as lmc
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze floorplan fengshui missing corners")
+    parser.add_argument("json", help="Path to floorplan JSON")
+    parser.add_argument("--threshold", type=float, default=0.6, help="Coverage threshold for missing corner")
+    parser.add_argument("--output", help="Optional path to save report")
+    args = parser.parse_args()
+
+    doc = load_floorplan_json(args.json)
+    with open(args.json, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    polygon = raw.get("polygon") or raw.get("floor_polygon") or raw.get("outline")
+    if not polygon:
+        raise ValueError("JSON 缺少 polygon 字段")
+
+    lmc.NORTH_ANGLE = getattr(doc, "north_angle", lmc.NORTH_ANGLE)
+    lmc.HOUSE_ORIENTATION = getattr(doc, "house_orientation", lmc.HOUSE_ORIENTATION)
+
+    result = lmc.analyze_missing_corners(polygon, doc.img_w, doc.img_h, threshold=args.threshold)
+    lines = [
+        f"{item['direction']}方缺角 覆盖率{item['coverage']:.2f} -> {item['suggestion']}" for item in result
+    ]
+    report = "\n".join(lines) if lines else "无明显缺角"
+    print(report)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/fengshui/luoshu_missing_corner.py
+++ b/fengshui/luoshu_missing_corner.py
@@ -1,0 +1,99 @@
+"""Identify missing corners of a floorplan using a 3x3 Luo Shu grid."""
+from __future__ import annotations
+
+import math
+from typing import Iterable, List, Tuple, Dict
+
+import cv2
+import numpy as np
+
+# Default orientation parameters; callers may override these module level variables
+NORTH_ANGLE: int = 90  # 0=East, 90=North as used in editor.models
+HOUSE_ORIENTATION: str = "坐北朝南"
+
+DIRECTION_NAMES = ["东", "东北", "北", "西北", "西", "西南", "南", "东南"]
+
+# Mapping from direction to simple fengshui suggestions
+SUGGESTIONS: Dict[str, str] = {
+    "东": "东侧缺角可摆放绿植以增旺木气。",
+    "东北": "东北缺角建议保持光线充足，放置瓷器装饰。",
+    "北": "北方缺角可用水景或蓝色饰品来化解。",
+    "西北": "西北缺角可悬挂金属风铃增强金气。",
+    "西": "西侧缺角宜放置白色或金属饰品以补足。",
+    "西南": "西南缺角可摆放陶土饰物或黄色家具。",
+    "南": "南方缺角可采用红色灯光或木饰品改善。",
+    "东南": "东南缺角可种植常绿植物以提升生气。",
+}
+
+
+def _direction_from_point(cx: int, cy: int, img_w: int, img_h: int, north_angle: int) -> str:
+    """Convert a point to a compass direction considering north angle."""
+    dx = cx - img_w / 2.0
+    dy = cy - img_h / 2.0
+    angle = (math.degrees(math.atan2(-dy, dx)) + 360.0) % 360.0  # 0=East, 90=North
+    angle = (angle - north_angle + 360.0) % 360.0
+    idx = int(((angle + 22.5) % 360) / 45)
+    return DIRECTION_NAMES[idx]
+
+
+def analyze_missing_corners(
+    polygon_points: Iterable[Tuple[float, float]],
+    width: int,
+    height: int,
+    threshold: float = 0.6,
+) -> List[Dict[str, object]]:
+    """Analyze which sectors of a 3x3 grid are missing from the floorplan.
+
+    Parameters
+    ----------
+    polygon_points: iterable of (x, y)
+        Vertices of the floorplan polygon.
+    width, height: int
+        Size of the image containing the polygon.
+    threshold: float, optional
+        Minimum coverage ratio required to consider the sector present.
+
+    Returns
+    -------
+    list of dict
+        Each dict contains `direction`, `coverage`, and `suggestion` keys.
+    """
+    pts = np.array(list(polygon_points), dtype=np.int32)
+    if pts.size == 0:
+        return []
+
+    mask = np.zeros((height, width), np.uint8)
+    cv2.fillPoly(mask, [pts], 1)
+
+    min_x, min_y = pts.min(axis=0)
+    max_x, max_y = pts.max(axis=0)
+
+    grid_w = (max_x - min_x) / 3.0
+    grid_h = (max_y - min_y) / 3.0
+
+    missing: List[Dict[str, object]] = []
+    for gy in range(3):
+        for gx in range(3):
+            x1 = int(min_x + gx * grid_w)
+            x2 = int(min_x + (gx + 1) * grid_w)
+            y1 = int(min_y + gy * grid_h)
+            y2 = int(min_y + (gy + 1) * grid_h)
+            if x2 <= x1 or y2 <= y1:
+                continue
+            cell = mask[y1:y2, x1:x2]
+            total = cell.size
+            cover = float(cell.sum())
+            ratio = cover / total if total else 0.0
+            if ratio < threshold:
+                cx = (x1 + x2) // 2
+                cy = (y1 + y2) // 2
+                direction = _direction_from_point(cx, cy, width, height, NORTH_ANGLE)
+                suggestion = SUGGESTIONS.get(direction, "可通过合理布置改善气场。")
+                missing.append(
+                    {
+                        "direction": direction,
+                        "coverage": round(ratio, 3),
+                        "suggestion": suggestion,
+                    }
+                )
+    return missing


### PR DESCRIPTION
## Summary
- add `fengshui` package with Luo Shu based missing corner detection
- provide CLI via `analyze_fengshui.py` and `python -m fengshui`
- document Fengshui analysis usage in README

## Testing
- `python analyze_fengshui.py sample_floorplan.json --threshold 0.8` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install opencv-python-headless` *(fails: Could not connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_68b47626af74832ab7b7c5babb968569