### PR TITLE
Add Bazhai eight-star Fengshui analysis CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,23 @@ python postprocess.py --result_dir=./[result_folder_path]
 
 ## Fengshui analysis
 
-A simple tool is provided to analyze missing corners of a floorplan based on Luo Shu nine-palace principles.
+A simple tool is provided to analyze a floorplan using Fengshui principles.
+It supports two modes:
+
+* ``luoshu`` (default) – detect missing corners using the Luo Shu
+  nine-palace method.
+* ``bazhai`` – evaluate each room's direction with BaZhai (Eight
+  Mansions) and output the corresponding star and suggestion.
 
 ```bash
-python analyze_fengshui.py path/to/floorplan.json --threshold 0.6
+python analyze_fengshui.py path/to/floorplan.json --mode luoshu --threshold 0.6
 # or
-python -m fengshui path/to/floorplan.json --threshold 0.6
+python analyze_fengshui.py path/to/floorplan.json --mode bazhai
 ```
 
-The command prints detected missing directions and suggestions and can save the report with `--output`.
+In ``bazhai`` mode the command prints lines of the form
+``房间 方位 八星 建议`` and in ``luoshu`` mode it reports detected missing
+directions. Use ``--output`` to save the report.
 
 
 ## Citation

--- a/analyze_fengshui.py
+++ b/analyze_fengshui.py
@@ -1,4 +1,13 @@
-"""Command line utility to analyze floorplan fengshui."""
+"""Command line utility to analyze floorplan fengshui.
+
+Run either *Luo Shu* missing-corner detection or *BaZhai* eight-star
+analysis depending on ``--mode``:
+
+.. code-block:: bash
+
+    python analyze_fengshui.py path/to/floorplan.json --mode luoshu
+    python analyze_fengshui.py path/to/floorplan.json --mode bazhai
+"""
 from fengshui.__main__ import main
 
 if __name__ == "__main__":

--- a/fengshui/__init__.py
+++ b/fengshui/__init__.py
@@ -1,4 +1,12 @@
-"""Fengshui utilities for floorplan analysis."""
+"""Fengshui utilities for floorplan analysis.
+
+This package currently provides:
+
+* ``analyze_missing_corners`` – detect missing corners using the
+  *Luo Shu* nine-palace principles.
+* ``analyze_eightstars`` – evaluate room orientations with the
+  *BaZhai* (Eight Mansions) method.
+"""
 
 from .luoshu_missing_corner import analyze_missing_corners
 from .bazhai_eightstars import analyze_eightstars


### PR DESCRIPTION
## Summary
- expose `analyze_eightstars` in the `fengshui` package
- add `--mode` option to Fengshui CLI with new `bazhai` analysis
- document Fengshui modes and usage examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b47a3e3870832aae25ee3c0713ca62