### PR TITLE
Add Fengshui remedy guidelines to analysis utilities

### DIFF
--- a/fengshui/__init__.py
+++ b/fengshui/__init__.py
@@ -6,9 +6,16 @@ This package currently provides:
   *Luo Shu* nine-palace principles.
 * ``analyze_eightstars`` – evaluate room orientations with the
   *BaZhai* (Eight Mansions) method.
+* ``general_remedies`` – common remedies for *Luo Shu* missing corners.
+* ``general_guidelines`` – generic layout tips for the *BaZhai* method.
 """
 
-from .luoshu_missing_corner import analyze_missing_corners
-from .bazhai_eightstars import analyze_eightstars
+from .luoshu_missing_corner import analyze_missing_corners, general_remedies
+from .bazhai_eightstars import analyze_eightstars, general_guidelines
 
-__all__ = ["analyze_missing_corners", "analyze_eightstars"]
+__all__ = [
+    "analyze_missing_corners",
+    "analyze_eightstars",
+    "general_remedies",
+    "general_guidelines",
+]

--- a/fengshui/__main__.py
+++ b/fengshui/__main__.py
@@ -2,7 +2,7 @@ import argparse
 import json
 
 from editor.json_io import load_floorplan_json
-from . import analyze_eightstars, luoshu_missing_corner as lmc
+from . import analyze_eightstars, luoshu_missing_corner as lmc, general_guidelines
 
 
 def main():
@@ -44,6 +44,10 @@ def main():
             f"{item['direction']}方缺角 覆盖率{item['coverage']:.2f} -> {item['suggestion']}"
             for item in result
         ]
+        if result:
+            lines.append("")
+            lines.append("常见化解思路：")
+            lines.extend(lmc.general_remedies())
         report = "\n".join(lines) if lines else "无明显缺角"
     else:  # bazhai
         rooms = [{"bbox": r.bbox, "name": r.type} for r in doc.rooms]
@@ -52,6 +56,10 @@ def main():
             f"{item['room']} {item['direction']} {item['star']} {item['suggestion']}"
             for item in result
         ]
+        if lines:
+            lines.append("")
+            lines.append("八宅调整建议：")
+            lines.extend(general_guidelines())
         report = "\n".join(lines) if lines else "无房间信息"
 
     print(report)

--- a/fengshui/bazhai_eightstars.py
+++ b/fengshui/bazhai_eightstars.py
@@ -108,6 +108,20 @@ STAR_INFO: Dict[str, Tuple[str, str]] = {
     "五鬼": ("凶", "不宜久留，可用火光或红色调化解。"),
 }
 
+# General guidelines for applying BaZhai adjustments
+GENERAL_GUIDELINES: List[str] = [
+    "根据出生年份确定居住者命卦，判定东四命或西四命。",
+    "主要房间尽量安排在与命卦相合的吉方，如卧室、书房等。",
+    "凶星方位宜作次要空间，吉星方布置核心功能区。",
+    "依五行调配颜色与摆设，并保持良好通风采光。",
+    "以实用与舒适为先，如无法变动位置可采取折中化解。",
+]
+
+
+def general_guidelines() -> List[str]:
+    """Return generic layout guidelines for the BaZhai eight-star method."""
+    return GENERAL_GUIDELINES.copy()
+
 
 def _direction_from_point(cx: float, cy: float, ox: float, oy: float, north_angle: float) -> str:
     """Convert a point to compass direction considering north angle."""

--- a/fengshui/luoshu_missing_corner.py
+++ b/fengshui/luoshu_missing_corner.py
@@ -25,6 +25,19 @@ SUGGESTIONS: Dict[str, str] = {
     "东南": "东南缺角可种植常绿植物以提升生气。",
 }
 
+# Generic remedies applicable to任何缺角的常见化解思路
+GENERAL_REMEDIES: List[str] = [
+    "使用功能性家具\u201c补角\u201d，如书柜、衣柜贴墙摆放。",
+    "在缺角方位摆放生机盎然的植物或装饰品，营造圆满感。",
+    "利用镜面或柔和灯光扩大空间感，增强该方位气场。",
+    "结合房屋用途在相邻方位调整布局，以弥补不利影响。",
+]
+
+
+def general_remedies() -> List[str]:
+    """Return common remedies for Luo Shu missing-corner issues."""
+    return GENERAL_REMEDIES.copy()
+
 
 def _direction_from_point(cx: int, cy: int, img_w: int, img_h: int, north_angle: int) -> str:
     """Convert a point to a compass direction considering north angle."""


### PR DESCRIPTION
## Summary
- Provide general remedies for Luo Shu missing-corner analysis
- Add BaZhai eight-star adjustment guidelines and expose them in package API
- Update CLI to append remedy and guideline suggestions to reports

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b4df098144832aa152fa46e1d3aa99