### PR TITLE
Add house-orientation mapping for BaZhai eight-star analysis

### DIFF
--- a/fengshui/__main__.py
+++ b/fengshui/__main__.py
@@ -22,6 +22,10 @@ def main():
         default=0.6,
         help="Coverage threshold for missing corner (luoshu mode)",
     )
+    parser.add_argument(
+        "--gua",
+        help="Personal Ming Gua for BaZhai analysis; if omitted, use the house orientation",
+    )
     parser.add_argument("--output", help="Optional path to save report")
     args = parser.parse_args()
 
@@ -51,9 +55,9 @@ def main():
         report = "\n".join(lines) if lines else "无明显缺角"
     else:  # bazhai
         rooms = [{"bbox": r.bbox, "name": r.type} for r in doc.rooms]
-        result = analyze_eightstars(polygon, rooms, doc)
+        result = analyze_eightstars(polygon, rooms, doc, gua=args.gua)
         lines = [
-            f"{item['room']} {item['direction']} {item['star']} {item['suggestion']}"
+            f"{item['room']} {item['direction']} {item['star']} {item['nature']} {item['suggestion']}"
             for item in result
         ]
         if lines:

--- a/test_bazhai_orientation.py
+++ b/test_bazhai_orientation.py
@@ -1,0 +1,49 @@
+"""Unit tests for BaZhai eight-star placement based on house orientation."""
+
+# Import the target module without importing the package (which requires heavy
+# dependencies like OpenCV). This keeps the test lightweight while still
+# exercising the public API.
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+module_path = Path(__file__).parent / "fengshui" / "bazhai_eightstars.py"
+spec = spec_from_file_location("bazhai_eightstars", module_path)
+bazhai = module_from_spec(spec)
+spec.loader.exec_module(bazhai)  # type: ignore
+
+analyze_eightstars = bazhai.analyze_eightstars
+HOUSE_DIRECTION_STARS = bazhai.HOUSE_DIRECTION_STARS
+
+
+def _sample_layout():
+    """Return a simple square layout with one room in each direction."""
+    polygon = [(0, 0), (100, 0), (100, 100), (0, 100)]
+    centers = {
+        "东": (80, 50),
+        "东北": (80, 80),
+        "北": (50, 80),
+        "西北": (20, 80),
+        "西": (20, 50),
+        "西南": (20, 20),
+        "南": (50, 20),
+        "东南": (80, 20),
+    }
+    rooms = [{"name": name, "center": c} for name, c in centers.items()]
+    return polygon, rooms
+
+
+def test_orientation_east_house():
+    polygon, rooms = _sample_layout()
+    orientation = {"north_angle": 90, "house_orientation": "坐北朝南"}
+    result = analyze_eightstars(polygon, rooms, orientation)
+    mapping = {item["direction"]: item["star"] for item in result}
+    assert mapping == HOUSE_DIRECTION_STARS["坐北朝南"]
+
+
+def test_orientation_west_house():
+    polygon, rooms = _sample_layout()
+    orientation = {"north_angle": 90, "house_orientation": "坐西北朝东南"}
+    result = analyze_eightstars(polygon, rooms, orientation)
+    mapping = {item["direction"]: item["star"] for item in result}
+    assert mapping == HOUSE_DIRECTION_STARS["坐西北朝东南"]
+


### PR DESCRIPTION
## Summary
- map house orientation phrases to eight-star distributions
- enable analyze_eightstars to use orientation-based stars when Ming Gua absent
- expose Ming Gua option in CLI and show star nature in output
- add tests verifying star placement for east and west house orientations

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install numpy opencv-python-headless -q` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python -m pytest test_bazhai_orientation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b9892db4832a8486c6f20f74105c