### PR TITLE
fix: improve eight-star and mountain visuals

### DIFF
--- a/luoshu_visualizer.py
+++ b/luoshu_visualizer.py
@@ -694,18 +694,16 @@ def draw_text_with_background(draw, text, position, font, text_color=(255, 255, 
     return text_width, text_height
 
 def get_star_colors():
-    """返回八星对应的颜色（与STAR_INFO保持一致）"""
-    return {
-        "生气": (0, 255, 0),    # 绿色 - 最吉
-        "延年": (0, 200, 0),    # 深绿 - 吉
-        "天医": (0, 150, 255),  # 橙色 - 吉 
-        "伏位": (255, 255, 0),  # 黄色 - 小吉
-        "中宫": (128, 128, 128), # 灰色 - 中性
-        "绝命": (0, 0, 255),    # 红色 - 大凶
-        "五鬼": (0, 0, 200),    # 深红 - 凶
-        "六煞": (0, 100, 255),  # 橙红 - 小凶
-        "祸害": (0, 50, 200)    # 深橙红 - 凶
-    }
+    """返回八星对应的BGR颜色，按吉凶区分"""
+    colors = {"中宫": (128, 128, 128)}
+    for star, (nature, _) in STAR_INFO.items():
+        if nature == "吉":
+            colors[star] = (0, 0, 255)   # 红色
+        elif nature == "凶":
+            colors[star] = (0, 255, 255) # 黄色
+        else:
+            colors[star] = (128, 128, 128)
+    return colors
 
 def draw_luoshu_grid_with_missing_corners(image, rooms_data, polygon=None, overlay_alpha=0.7, missing_corners=None, original_image_path=None, north_angle=0):
     """在图像上绘制九宫格，显示缺角信息，支持动态朝向"""
@@ -1351,24 +1349,20 @@ def draw_bazhai_circle(image, direction_stars_mapping, polygon=None, rooms_data=
         print(f"使用图像中心圆: 中心({center_x:.1f}, {center_y:.1f}), 半径{radius:.1f}")
     
     colors = get_star_colors()
-    
+
     # 确保圆形有足够大小，并为文字标签留出空间
     min_radius = min(w, h) / 5  # 最小半径
     radius = max(radius, min_radius)
-    
+
     # 获取字体 - 调整为更小的字体
     font_size = int(radius) // 10  # 大幅减小字体大小
     direction_font = get_chinese_font(max(12, font_size))  # 方位文字用更小字体
     star_font = get_chinese_font(max(14, font_size + 2))   # 星位文字稍大一些
-    
+
     # 八个方位的角度（根据north_angle动态调整）
     # 在PIL中，角度0度是右方（东），顺时针为正
     direction_angles = get_bazhai_direction_angles(north_angle)
-    
-    # 定义吉凶星位
-    auspicious_stars = {"生气", "延年", "天医", "伏位"}  # 吉四星
-    inauspicious_stars = {"绝命", "五鬼", "六煞", "祸害"}  # 凶四星
-    
+
     # 绘制八个扇形区域
     for direction, angle in direction_angles.items():
         if direction == "中":  # 跳过中心
@@ -1389,14 +1383,16 @@ def draw_bazhai_circle(image, direction_stars_mapping, polygon=None, rooms_data=
                 pass
         if not star:
             star = "未知"
-        
-        # 根据吉凶星位确定填充颜色
-        if star in auspicious_stars:
-            # 吉四星用半透明红色填充（增强不透明度）
-            fill_color = (255, 0, 0, 150)  # 更明显的半透明红色
-        elif star in inauspicious_stars:
-            # 凶四星用半透明黄色填充（增强不透明度）
-            fill_color = (255, 255, 0, 150)  # 更明显的半透明黄色
+
+        star = star.strip()
+        nature = STAR_INFO.get(star, ("", ""))[0]
+
+        # 根据吉凶星位确定填充颜色，透明度20%
+        alpha = int(255 * 0.2)
+        if nature == "吉":
+            fill_color = (255, 0, 0, alpha)
+        elif nature == "凶":
+            fill_color = (255, 255, 0, alpha)
         else:
             fill_color = None
         
@@ -1426,38 +1422,47 @@ def draw_bazhai_circle(image, direction_stars_mapping, polygon=None, rooms_data=
         # 绘制方位文字（在圆外面）
         direction_text = direction
         star_text = f"{star}" if star != "未知" else star
-        
+
         if direction_font:
             # 方位文字 - 在圆外面
             bbox = draw.textbbox((0, 0), direction_text, font=direction_font)
             text_w = bbox[2] - bbox[0]
             text_h = bbox[3] - bbox[1]
-            
+
             label_x = direction_x - text_w//2
             label_y = direction_y - text_h//2
-            
+
+            # 防止文字超出边界
+            label_x = max(0, min(label_x, w - text_w))
+            label_y = max(0, min(label_y, h - text_h))
+
             # 直接绘制文字，黑色字体
             draw.text((label_x, label_y), direction_text, font=direction_font, fill=(0, 0, 0, 255))
-        
+
         if star_font:
-            # 星位文字 - 在圆内，吉星用红色，凶星用黑色
+            # 星位文字 - 在圆内，根据吉凶选择文字颜色
             bbox = draw.textbbox((0, 0), star_text, font=star_font)
             text_w = bbox[2] - bbox[0]
             text_h = bbox[3] - bbox[1]
-            
+
             label_x = star_x - text_w//2
             label_y = star_y - text_h//2
-            
-            # 根据星位类型选择文字颜色
-            if star in auspicious_stars:
-                text_color = (200, 0, 0, 255)  # 吉星用红色
-            else:
-                text_color = (0, 0, 0, 255)    # 凶星用黑色
-            
+
+            # 防止文字超出边界并留出边距，避免北与东北方向被截断
+            padding = 5
+            label_x = max(padding, min(label_x, w - text_w - padding))
+            label_y = max(padding, min(label_y, h - text_h - padding))
+
+            text_color = (0, 0, 0, 255)
+
             # 在星位文字下绘制半透明白底提高可读性
             try:
                 bg_pad = 2
-                draw.rectangle([label_x - bg_pad, label_y - bg_pad, label_x + text_w + bg_pad, label_y + text_h + bg_pad], fill=(255, 255, 255, 180))
+                bg_x1 = max(0, label_x - bg_pad)
+                bg_y1 = max(0, label_y - bg_pad)
+                bg_x2 = min(w, label_x + text_w + bg_pad)
+                bg_y2 = min(h, label_y + text_h + bg_pad)
+                draw.rectangle([bg_x1, bg_y1, bg_x2, bg_y2], fill=(255, 255, 255, 180))
             except Exception:
                 pass
             draw.text((label_x, label_y), star_text, font=star_font, fill=text_color)
@@ -1619,16 +1624,13 @@ def draw_twentyfour_mountains(image, polygon=None, north_angle=0, overlay_alpha=
         # 使用图像中心
         center_x = w // 2
         center_y = h // 2
+        circle_radius = min(w, h) / 2 - 10
         print(f"二十四山太极点（图像中心）: 中心({center_x}, {center_y})")
-    
-    # 计算合适的半径
-    if polygon:
-        # 根据多边形大小确定半径
-        distances = [np.sqrt((x - center_x)**2 + (y - center_y)**2) for x, y in polygon]
-        base_radius = min(max(distances) * 0.8, min(w, h) * 0.35)
-    else:
-        base_radius = min(w, h) * 0.35
-    
+
+    # 计算合适的半径，外层圆完整包裹户型图
+    base_radius = circle_radius
+    base_radius = min(base_radius, min(w, h) / 2 - 10)
+
     # 设置三层圆环半径
     outer_radius = int(base_radius)          # 外层：二十四山
     middle_radius = int(base_radius * 0.7)   # 中层：八卦


### PR DESCRIPTION
## Summary
- derive star legend colors from STAR_INFO nature
- render star sectors with correct auspicious/inauspicious colors at 20% opacity and pad labels to prevent clipping

## Testing
- `python -m py_compile luoshu_visualizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68be4a6fb2ac832a89e960cb79c23239